### PR TITLE
direct crafting

### DIFF
--- a/data.lua
+++ b/data.lua
@@ -4,3 +4,6 @@ end
 if settings.startup["experiments-directsmelting"].value then
 	require("prototypes.directsmelting")
 end
+if settings.startup["experiments-directcrafting"].value then
+	require("prototypes.directcrafting")
+end

--- a/prototypes/directcrafting.lua
+++ b/prototypes/directcrafting.lua
@@ -1,0 +1,151 @@
+local iron_density = deadlock.get_item_stack_density("iron-plate", "item")
+local gear_density = deadlock.get_item_stack_density("iron-gear-wheel", "item")
+local gear = {
+  type = "recipe",
+  name = "stacked-iron-gear-wheel",
+  normal = {
+    enabled = true,
+    energy_required = 0.5 * gear_density,
+    ingredients = {{"deadlock-stack-iron-plate", 2}},
+    result = "deadlock-stack-iron-gear-wheel",
+  },
+  expensive = {
+    enabled = true,
+    energy_required = 0.5 * gear_density,
+    ingredients = {{"deadlock-stack-iron-plate", 4}},
+    result = "deadlock-stack-iron-gear-wheel",
+  },
+}
+
+data:extend({gear})
+-- add the unlock of the tech for the steel recipe to the steel tech
+-- table.insert(data.raw.technology["steel-processing"].effects, {recipe = "stacked-steel-plate", type = "unlock-recipe"})
+
+local iron_density = deadlock.get_item_stack_density("iron-plate", "item")
+local copper_density = deadlock.get_item_stack_density("copper-plate", "item")
+local coal_density = deadlock.get_item_stack_density("coal", "item")
+local plastic_bar_density = deadlock.get_item_stack_density("plastic-bar", "item")
+local cable_density = deadlock.get_item_stack_density("copper-cable", "item")
+local electronic_circuit_density = deadlock.get_item_stack_density("electronic-circuit", "item")
+local advanced_circuit_density = deadlock.get_item_stack_density("advanced-circuit", "item")
+local processing_unit_density = deadlock.get_item_stack_density("processing-unit", "item")
+-- we assume all these are equal. Otherwise ratios will be screwed
+
+local stacked_cable = {
+  type = "recipe",
+  name = "stacked-copper-cable",
+  normal = {
+    enabled = true,
+    energy_required = 0.5 * cable_density,
+    ingredients = {{"deadlock-stack-copper-plate", 1}},
+    results = {{"deadlock-stack-copper-cable",2}},
+  },
+  expensive = {
+      enabled = true,
+      energy_required = 0.5 * cable_density,
+      ingredients = {{"deadlock-stack-copper-plate", 1}},
+      results = {{"deadlock-stack-copper-cable",2}},
+  },
+}
+
+local stacked_electronic_circuit = {
+  type = "recipe",
+  name = "stacked-electronic-circuit",
+  normal = {
+    enabled = true,
+    energy_required = 0.5 * electronic_circuit_density,
+    ingredients = {{"deadlock-stack-copper-cable", 3}, {"deadlock-stack-iron-plate", 1}},
+    result = "deadlock-stack-electronic-circuit",
+  },
+  expensive = {
+      enabled = true,
+      energy_required = 0.5 * electronic_circuit_density,
+      ingredients = {{"deadlock-stack-copper-cable", 8}, {"deadlock-stack-iron-plate", 2}},
+      result = "deadlock-stack-electronic-circuit",
+  },
+}
+
+local stacked_advanced_circuit = {
+  type = "recipe",
+  name = "stacked-advanced-circuit",
+  normal = {
+    enabled = true,
+    energy_required = 6.0 * advanced_circuit_density,
+    ingredients = {{"deadlock-stack-copper-cable", 4}, {"deadlock-stack-electronic-circuit", 2}, {"deadlock-stack-plastic-bar", 2}},
+    result = "deadlock-stack-advanced-circuit",
+  },
+  expensive = {
+      enabled = true,
+      energy_required = 6.0 * advanced_circuit_density,
+      ingredients = {{"deadlock-stack-copper-cable", 8}, {"deadlock-stack-electronic-circuit", 2}, {"deadlock-stack-plastic-bar", 4}},
+      result = "deadlock-stack-advanced-circuit",
+  },
+}
+
+local stacked_processing_unit = {
+  type = "recipe",
+  name = "stacked-processing-unit",
+  category = "crafting-with-fluid",
+  normal = {
+    enabled = true,
+    energy_required = 10.0 * advanced_circuit_density,
+    ingredients = {
+        {type="item", name="deadlock-stack-advanced-circuit", amount=2},
+        {type="item", name="deadlock-stack-electronic-circuit", amount=20},
+        {type="fluid", name="sulfuric-acid", amount=5*processing_unit_density}
+    },
+    result = "deadlock-stack-processing-unit",
+  },
+  expensive = {
+      enabled = true,
+      energy_required = 10.0 * advanced_circuit_density,
+      ingredients = {
+          {type="item", name="deadlock-stack-advanced-circuit", amount=2},
+          {type="item", name="deadlock-stack-electronic-circuit", amount=20},
+          {type="fluid", name="sulfuric-acid", amount=10*processing_unit_density}
+      },
+      result = "deadlock-stack-processing-unit",
+  },
+}
+
+local stacked_plastic_bar = {
+  type = "recipe",
+  name = "stacked-plastic-bar",
+  category = "chemistry",
+  energy_required = 1 * plastic_bar_density,
+  enabled = true,
+  ingredients =
+  {
+    {type="fluid", name="petroleum-gas", amount=20 * plastic_bar_density},
+    {type="item", name="deadlock-stack-coal", amount=1}
+  },
+  results=
+  {
+    {type="item", name="deadlock-stack-plastic-bar", amount=2}
+  },
+  crafting_machine_tint =
+  {
+    primary = {r = 1.000, g = 1.000, b = 1.000, a = 1.000}, -- #fefeffff
+    secondary = {r = 0.771, g = 0.771, b = 0.771, a = 1.000}, -- #c4c4c4ff
+    tertiary = {r = 0.768, g = 0.665, b = 0.762, a = 1.000}, -- #c3a9c2ff
+    quaternary = {r = 0.000, g = 0.000, b = 0.000, a = 1.000}, -- #000000ff
+  }
+}
+
+data:extend({stacked_cable})
+data:extend({stacked_electronic_circuit})
+data:extend({stacked_advanced_circuit})
+data:extend({stacked_processing_unit})
+data:extend({stacked_plastic_bar})
+
+-- enable productivity modules on the stacked version of intermediate products
+for k, v in pairs(data.raw.module) do
+  if v.name:find("productivity%-module") and v.limitation then
+    table.insert(v.limitation, "stacked-iron-gear-wheel")
+    table.insert(v.limitation, "stacked-copper-cable")
+    table.insert(v.limitation, "stacked-electronic-circuit")
+    table.insert(v.limitation, "stacked-advanced-circuit")
+    table.insert(v.limitation, "stacked-processing-unit")
+    table.insert(v.limitation, "stacked-plastic-bar")
+  end
+end

--- a/prototypes/directcrafting.lua
+++ b/prototypes/directcrafting.lua
@@ -4,22 +4,18 @@ local gear = {
   type = "recipe",
   name = "stacked-iron-gear-wheel",
   normal = {
-    enabled = true,
+    enabled = false,
     energy_required = 0.5 * gear_density,
     ingredients = {{"deadlock-stack-iron-plate", 2}},
     result = "deadlock-stack-iron-gear-wheel",
   },
   expensive = {
-    enabled = true,
+    enabled = false,
     energy_required = 0.5 * gear_density,
     ingredients = {{"deadlock-stack-iron-plate", 4}},
     result = "deadlock-stack-iron-gear-wheel",
   },
 }
-
-data:extend({gear})
--- add the unlock of the tech for the steel recipe to the steel tech
--- table.insert(data.raw.technology["steel-processing"].effects, {recipe = "stacked-steel-plate", type = "unlock-recipe"})
 
 local iron_density = deadlock.get_item_stack_density("iron-plate", "item")
 local copper_density = deadlock.get_item_stack_density("copper-plate", "item")
@@ -35,13 +31,13 @@ local stacked_cable = {
   type = "recipe",
   name = "stacked-copper-cable",
   normal = {
-    enabled = true,
+    enabled = false,
     energy_required = 0.5 * cable_density,
     ingredients = {{"deadlock-stack-copper-plate", 1}},
     results = {{"deadlock-stack-copper-cable",2}},
   },
   expensive = {
-      enabled = true,
+      enabled = false,
       energy_required = 0.5 * cable_density,
       ingredients = {{"deadlock-stack-copper-plate", 1}},
       results = {{"deadlock-stack-copper-cable",2}},
@@ -52,13 +48,13 @@ local stacked_electronic_circuit = {
   type = "recipe",
   name = "stacked-electronic-circuit",
   normal = {
-    enabled = true,
+    enabled = false,
     energy_required = 0.5 * electronic_circuit_density,
     ingredients = {{"deadlock-stack-copper-cable", 3}, {"deadlock-stack-iron-plate", 1}},
     result = "deadlock-stack-electronic-circuit",
   },
   expensive = {
-      enabled = true,
+      enabled = false,
       energy_required = 0.5 * electronic_circuit_density,
       ingredients = {{"deadlock-stack-copper-cable", 8}, {"deadlock-stack-iron-plate", 2}},
       result = "deadlock-stack-electronic-circuit",
@@ -69,13 +65,13 @@ local stacked_advanced_circuit = {
   type = "recipe",
   name = "stacked-advanced-circuit",
   normal = {
-    enabled = true,
+    enabled = false,
     energy_required = 6.0 * advanced_circuit_density,
     ingredients = {{"deadlock-stack-copper-cable", 4}, {"deadlock-stack-electronic-circuit", 2}, {"deadlock-stack-plastic-bar", 2}},
     result = "deadlock-stack-advanced-circuit",
   },
   expensive = {
-      enabled = true,
+      enabled = false,
       energy_required = 6.0 * advanced_circuit_density,
       ingredients = {{"deadlock-stack-copper-cable", 8}, {"deadlock-stack-electronic-circuit", 2}, {"deadlock-stack-plastic-bar", 4}},
       result = "deadlock-stack-advanced-circuit",
@@ -87,7 +83,7 @@ local stacked_processing_unit = {
   name = "stacked-processing-unit",
   category = "crafting-with-fluid",
   normal = {
-    enabled = true,
+    enabled = false,
     energy_required = 10.0 * advanced_circuit_density,
     ingredients = {
         {type="item", name="deadlock-stack-advanced-circuit", amount=2},
@@ -97,7 +93,7 @@ local stacked_processing_unit = {
     result = "deadlock-stack-processing-unit",
   },
   expensive = {
-      enabled = true,
+      enabled = false,
       energy_required = 10.0 * advanced_circuit_density,
       ingredients = {
           {type="item", name="deadlock-stack-advanced-circuit", amount=2},
@@ -113,7 +109,7 @@ local stacked_plastic_bar = {
   name = "stacked-plastic-bar",
   category = "chemistry",
   energy_required = 1 * plastic_bar_density,
-  enabled = true,
+  enabled = false,
   ingredients =
   {
     {type="fluid", name="petroleum-gas", amount=20 * plastic_bar_density},
@@ -131,7 +127,7 @@ local stacked_plastic_bar = {
     quaternary = {r = 0.000, g = 0.000, b = 0.000, a = 1.000}, -- #000000ff
   }
 }
-
+data:extend({gear})
 data:extend({stacked_cable})
 data:extend({stacked_electronic_circuit})
 data:extend({stacked_advanced_circuit})
@@ -149,3 +145,11 @@ for k, v in pairs(data.raw.module) do
     table.insert(v.limitation, "stacked-plastic-bar")
   end
 end
+
+-- add the unlock of direct-crafting to the stacking-techs
+table.insert(data.raw.technology["deadlock-stacking-2"].effects, {recipe = "stacked-iron-gear-wheel", type = "unlock-recipe"})
+table.insert(data.raw.technology["deadlock-stacking-2"].effects, {recipe = "stacked-copper-cable", type = "unlock-recipe"})
+table.insert(data.raw.technology["deadlock-stacking-2"].effects, {recipe = "stacked-electronic-circuit", type = "unlock-recipe"})
+table.insert(data.raw.technology["deadlock-stacking-2"].effects, {recipe = "stacked-advanced-circuit", type = "unlock-recipe"})
+table.insert(data.raw.technology["deadlock-stacking-2"].effects, {recipe = "stacked-plastic-bar", type = "unlock-recipe"})
+table.insert(data.raw.technology["deadlock-stacking-3"].effects, {recipe = "stacked-processing-unit", type = "unlock-recipe"})

--- a/settings.lua
+++ b/settings.lua
@@ -22,9 +22,16 @@ data:extend({
 		default_value = true,
 	},
 	{
+		type = "bool-setting",
+		name = "experiments-directcrafting",
+		order = "d",
+		setting_type = "startup",
+		default_value = true,
+	},
+	{
 		type = "string-setting",
 		name = "experiments-densityoverride",
-		order = "d",
+		order = "e",
 		setting_type = "startup",
 		default_value = "1",
 		allowed_values = {


### PR DESCRIPTION
This adds the option to directly craft iron-gears, plastic-bars, copper-cables, gree/red/blue-circuits using stacked ingredients with stacked output.

* recipes for vanilla normal and expensive mode (but does not take into account recipe changes by other mods)
* can be turned off in the settings (I set default=on, but feel free to change that)
* I am aware that Deadlock himself did not want this feature in the stacking mod itself, but this place might be appropriate
* before merging, need to bump version-number and add changelog (I wanted to wait for feedback before doing that)