### PR TITLE
Steel smelting fix

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -1,0 +1,9 @@
+local function on_load(event)
+  for _, force in pairs(game.forces) do
+    if force.technologies["steel-processing"].researched then
+      force.recipes["stacked-steel-plate"].enabled = true
+    end
+  end
+end
+
+script.on_init(on_load)


### PR DESCRIPTION
 - Unlock steel smelting recipe on startup if player has already unlocked the technology